### PR TITLE
Extend widget manager

### DIFF
--- a/src/samples/widgets.ts
+++ b/src/samples/widgets.ts
@@ -47,7 +47,7 @@ rotation.observable.subscribe( output => {
 });
 
 // display the image widget
-widgets.show(rotation);
+widgets.add(rotation);
 
 // set the loaded image as the widget input
 rotation.setInput('image', img);

--- a/src/ui/app.css
+++ b/src/ui/app.css
@@ -133,6 +133,10 @@ body {
     box-shadow: 1px 1px 3px #dadada;
 }
 
+.widget.hidden {
+    display: none;
+}
+
 .widget-title {
     padding: 3px 10px;
     background-color: #f7f7f7;

--- a/src/ui/widget-manager.ts
+++ b/src/ui/widget-manager.ts
@@ -124,6 +124,13 @@ export class WidgetManager {
     }
 
     /**
+     * removes all widgets from the widget manager
+     */
+    public removeAll () {
+        Object.keys(this.widgets).forEach(widgetId => this.remove(widgetId));
+    }
+
+    /**
      * shows all widgets in the widget manager
      */
     public showAll () {

--- a/src/ui/widget-manager.ts
+++ b/src/ui/widget-manager.ts
@@ -6,32 +6,120 @@ import {
 } from '@/core/widget';
 import { WidgetView } from './widget-view';
 
+const WIDGET_HIDDEN_CLASS = 'hidden';
+
 export class WidgetManager {
     readonly el: HTMLElement;
     private templates: {[name: string]: WidgetTemplate } = {};
-    private widgets: WidgetView[] = [];
+    private widgets: {[widgetId: string]: WidgetView } = {};
     private nextWidgetId = 1;
 
     constructor (el: HTMLElement) {
         this.el = el;
     }
 
+    /**
+     * creates and registers a new WidgetTemplate
+     * @param templateName name used to identify the registered template
+     * @param opts template options
+     */
     public define (templateName: string, opts: WidgetTemplateCreateArgs) {
         const template = createWidgetTemplate(templateName, opts);
         this.templates[templateName] = template;
         return template;
     }
 
+    /**
+     * creates a new widget based on the specified template
+     * @param templateName name of a registered template
+     */
     public create (templateName: string) {
         const template = this.templates[templateName];
         return template.create();
     }
 
-    public show(widget: WidgetModel) {
+    /**
+     * gets a registered template
+     * @param templateName name of the template
+     */
+    public getTemplate (templateName: string): WidgetTemplate {
+        return this.templates[templateName];
+    }
+
+    /**
+     * registers a template
+     * @param name
+     * @param template 
+     */
+    public setTemplate (name: string, template: WidgetTemplate) {
+        this.templates[name] = template;
+    }
+
+    public getWidget (widgetId: string): WidgetModel|undefined {
+        const widget = this.widgets[widgetId];
+        return widget && widget.model;
+    }
+
+    /**
+     * registers and displays the widget
+     * @param widget 
+     * @returns the id of the added widget
+     */
+    public add (widget: WidgetModel): string {
         const view = new WidgetView(widget);
-        view.el.id = `widget${this.nextWidgetId}`;
+        const widgetId = `widget${this.nextWidgetId}`;
+        view.el.id = widgetId;
         this.nextWidgetId += 1;
         this.el.appendChild(view.el);
-        this.widgets.push(view);
+        this.widgets[widgetId] = view;
+        return widgetId;
+    }
+
+    /**
+     * hides the specified widget
+     * @param widgetId
+     */
+    public hide (widgetId: string) {
+        const widget = this.widgets[widgetId];
+        if (widget) {
+            widget.el.classList.add(WIDGET_HIDDEN_CLASS);
+        }
+    }
+
+    /**
+     * displays the specified widget
+     * @param widgetId
+     */
+    public show (widgetId: string) {
+        const widget = this.widgets[widgetId];
+        if (widget) {
+            widget.el.classList.remove(WIDGET_HIDDEN_CLASS);
+        }
+    }
+
+    /**
+     * removes the specified widget from the widget manager
+     * @param widgetId
+     */
+    public remove (widgetId: string) {
+        const widget = this.widgets[widgetId];
+        if (widget) {
+            this.el.removeChild(widget.el);
+            delete this.widgets[widgetId];
+        }
+    }
+
+    /**
+     * shows all widgets in the widget manager
+     */
+    public showAll () {
+        Object.keys(this.widgets).forEach(widgetId => this.show(widgetId));
+    }
+
+    /**
+     * hides all widgets in the widget manager
+     */
+    public hideAll () {
+        Object.keys(this.widgets).forEach(widgetId => this.hide(widgetId));
     }
 }

--- a/src/ui/widget-manager.ts
+++ b/src/ui/widget-manager.ts
@@ -8,12 +8,19 @@ import { WidgetView } from './widget-view';
 
 const WIDGET_HIDDEN_CLASS = 'hidden';
 
+/**
+ * creates and manages widget templates and widgets on screen
+ */
 export class WidgetManager {
     readonly el: HTMLElement;
     private templates: {[name: string]: WidgetTemplate } = {};
     private widgets: {[widgetId: string]: WidgetView } = {};
     private nextWidgetId = 1;
 
+    /**
+     * 
+     * @param el container element for the widgets
+     */
     constructor (el: HTMLElement) {
         this.el = el;
     }

--- a/src/ui/widget-manager.ts
+++ b/src/ui/widget-manager.ts
@@ -31,11 +31,14 @@ export class WidgetManager {
 
     /**
      * creates a new widget based on the specified template
+     * and adds it to the widget manager then displays it.
+     * Returns the id of the widget
      * @param templateName name of a registered template
      */
-    public create (templateName: string) {
+    public create (templateName: string): string {
         const template = this.templates[templateName];
-        return template.create();
+        const widget = template.create();
+        return this.add(widget);
     }
 
     /**
@@ -55,15 +58,19 @@ export class WidgetManager {
         this.templates[name] = template;
     }
 
-    public getWidget (widgetId: string): WidgetModel|undefined {
+    /**
+     * gets widget by its id
+     * @param widgetId
+     */
+    public get (widgetId: string): WidgetModel|undefined {
         const widget = this.widgets[widgetId];
         return widget && widget.model;
     }
 
     /**
-     * registers and displays the widget
-     * @param widget 
-     * @returns the id of the added widget
+     * adds the widget to the widget manager and displays.
+     * Returns the id of the widget
+     * @param widget
      */
     public add (widget: WidgetModel): string {
         const view = new WidgetView(widget);


### PR DESCRIPTION
Made changes and added new methods to the `WidgetManager`:

- `create(templateName)` now creates a widget, and adds it to the manager. It returns the widget id instead of the actual widget
- add `getTemplate(name)` and `setTemplate(name, template)`
- `get(widgetId)`
- added the following methods to manage widget instances: `add`, `show`, `hide`, `remove`, `showAll`, `showHide`