### PR TITLE
Multiple outputs for widgets

### DIFF
--- a/src/core/widget/types.ts
+++ b/src/core/widget/types.ts
@@ -14,7 +14,8 @@ export interface WidgetOpts {
     name: string;
     params: WidgetParams;
     inputs: WidgetInputs;
-    onUpdate(ctx: WidgetModelContext): any;
+    outputs: WidgetOutputs;
+    onUpdate(ctx: WidgetModelContext): {[outputName: string]: any};
 }
 
 export interface WidgetParams {
@@ -35,6 +36,14 @@ export interface WidgetInputs {
 }
 
 export interface WidgetInputOpts {
+    type: WidgetArgDataType;
+}
+
+export interface WidgetOutputs {
+    [outputName: string]: WidgetOutputOpts;
+}
+
+export interface WidgetOutputOpts {
     type: WidgetArgDataType;
 }
 
@@ -73,6 +82,11 @@ export interface WidgetTemplateCreateArgs {
             type?: string
         }
     };
+    outputs: string[] | {
+        [outputName: string]: {
+            type?: string
+        }
+    }
     onUpdate (ctx: WidgetModelContext): any;
 }
 

--- a/src/core/widget/widget-template.ts
+++ b/src/core/widget/widget-template.ts
@@ -13,8 +13,11 @@ export function createWidgetTemplate (name: string, args: WidgetTemplateCreateAr
         name,
         params: {},
         inputs: {},
+        outputs: {},
         onUpdate: args.onUpdate
     };
+
+    // params
     for (let paramName in args.params) {
         const rawParams = args.params[paramName];
         const type = <WidgetArgDataType>args.params[paramName].type || WidgetArgDataType.Number;
@@ -28,6 +31,8 @@ export function createWidgetTemplate (name: string, args: WidgetTemplateCreateAr
             step: rawParams.step
         };
     }
+
+    // inputs
     if (Array.isArray(args.inputs)) {
         for (let inputName of args.inputs) {
             opts.inputs[inputName] = {
@@ -41,6 +46,22 @@ export function createWidgetTemplate (name: string, args: WidgetTemplateCreateAr
                type: <WidgetArgDataType>args.inputs[inputName].type || WidgetArgDataType.Any
            }
        }
+    }
+
+    // outputs
+    if (Array.isArray(args.outputs)) {
+        for (let outputName of args.outputs) {
+            opts.outputs[outputName] = {
+                type: WidgetArgDataType.Any
+            }
+        }
+    }
+    else {
+        for (let outputName in args.outputs) {
+            opts.outputs[outputName] = {
+                type: <WidgetArgDataType>args.outputs[outputName].type || WidgetArgDataType.Any
+            }
+        }
     }
 
     return {

--- a/src/samples/widgets.ts
+++ b/src/samples/widgets.ts
@@ -24,6 +24,8 @@ const Rotation = widgets.define('Rotation', {
     },
     // define inputs
     inputs: ['image'],
+    // define outputs
+    outputs: ['image'],
     // define the computation triggered by the widget
     onUpdate (ctx) {
         const { inputs: { image }, params: { angle, scale } } = ctx;
@@ -33,7 +35,7 @@ const Rotation = widgets.define('Rotation', {
         const M = cv.getRotationMatrix2D(center, angle, scale);
         cv.warpAffine(image, dst, M, dsize, cv.INTER_LINEAR, cv.BORDER_CONSTANT, new cv.Scalar());
         M.delete();
-        return dst;
+        return { image: dst };
     }
 });
 
@@ -41,9 +43,9 @@ const Rotation = widgets.define('Rotation', {
 const rotation = Rotation.create();
 
 // attach the widget to the image viewer
-rotation.observable.subscribe( output => {
-    imviewer.show(output);
-    output.delete();
+rotation.observable.subscribe(({ image }) => {
+    imviewer.show(image);
+    image.delete();
 });
 
 // display the image widget


### PR DESCRIPTION
Addresses #21 

Widget template opts now must declare `outputs` similar to how `inputs` are declared, and the `onUpdate` should return an object with a key for each output.

Here's an excerpt from the update sample code:

```javascript
// define a custom widget template
const Rotation = widgets.define('Rotation', {
    // define parameters for this widget
    params: {
        angle: {
            type: 'number',
            min: -180,
            max: 180,
            initial: 0
        },
        scale: {
            type: 'number',
            initial: 1,
            min: 0,
            max: 5,
            step: 0.1
        }
    },
    // define inputs
    inputs: ['image'],
    // define outputs
    outputs: ['image'],
    // define the computation triggered by the widget
    onUpdate (ctx) {
        const { inputs: { image }, params: { angle, scale } } = ctx;
        const dst = new cv.Mat();
        const dsize = new cv.Size(image.rows, image.cols);
        const center = new cv.Point(image.cols / 2, image.rows / 2);
        const M = cv.getRotationMatrix2D(center, angle, scale);
        cv.warpAffine(image, dst, M, dsize, cv.INTER_LINEAR, cv.BORDER_CONSTANT, new cv.Scalar());
        M.delete();
        return { image: dst };
    }
});
```