### PR TITLE
Improve widgets i/o api

### DIFF
--- a/src/core/widget/types.ts
+++ b/src/core/widget/types.ts
@@ -64,8 +64,10 @@ export interface WidgetModel extends DataSource<WidgetUpdateResult> {
     opts: WidgetOpts;
     state: WidgetModelContext;
     setInput(inputName: string, value: any): void;
+    setInputs(inputs: {[name: string]: any}): void;
     getInput(inputName: string): any;
     setParam(paramName: string, value: any): void;
+    setParams(params: {[name: string]: any}): void;
     getParam(paramName: string): any;
     update(): any;
     pipeOutput(name: string, dest: DataSink<any>): DataSink<any>;

--- a/src/core/widget/types.ts
+++ b/src/core/widget/types.ts
@@ -18,6 +18,10 @@ export interface WidgetOpts {
     onUpdate(ctx: WidgetModelContext): {[outputName: string]: any};
 }
 
+export interface WidgetUpdateResult {
+    [outputName: string]: any;
+}
+
 export interface WidgetParams {
     [paramName: string]: WidgetParamOpts;
 }
@@ -56,7 +60,7 @@ export interface WidgetModelContext {
     }
 }
 
-export interface WidgetModel extends DataSource<any> {
+export interface WidgetModel extends DataSource<WidgetUpdateResult> {
     opts: WidgetOpts;
     state: WidgetModelContext;
     setInput(inputName: string, value: any): void;
@@ -64,6 +68,7 @@ export interface WidgetModel extends DataSource<any> {
     setParam(paramName: string, value: any): void;
     getParam(paramName: string): any;
     update(): any;
+    pipeOutput(name: string, dest: DataSink<any>): DataSink<any>;
 }
 
 export interface WidgetTemplateCreateArgs {

--- a/src/core/widget/types.ts
+++ b/src/core/widget/types.ts
@@ -62,19 +62,80 @@ export interface WidgetModelContext {
 }
 
 export interface WidgetModel extends DataSource<WidgetUpdateResult> {
+    /**
+     * template options used to create the widget
+     */
     opts: WidgetOpts;
+    /**
+     * contains current state (inputs and params) of the widget
+     */
     state: WidgetModelContext;
+    /**
+     * maps each input to a data sink
+     */
     inputs: {[name: string]: DataSink<any>},
+    /**
+     * maps each output to a data source
+     */
     outputs: {[name: string]: DataSource<any>},
+    /**
+     * cache of observables for each output
+     * @internal
+     */
     _outputsObservables: {[name: string]: Observable<any>};
+    /**
+     * updates the specified input
+     * this updates the widget
+     * @param inputName
+     * @param value 
+     */
     setInput(inputName: string, value: any): void;
+    /**
+     * updates multiple inputs at a go, then updates
+     * the widget
+     * @param inputs 
+     */
     setInputs(inputs: {[name: string]: any}): void;
+    /**
+     * gets the current value of the specified input
+     * @param inputName
+     */
     getInput(inputName: string): any;
+    /**
+     * updates the specified param,
+     * then updates the widget
+     * @param paramName 
+     * @param value 
+     */
     setParam(paramName: string, value: any): void;
+    /**
+     * updates multiple params at a go,
+     * then updates the widget
+     * @param params 
+     */
     setParams(params: {[name: string]: any}): void;
+    /**
+     * gets the current value of the specified param
+     * @param paramName
+     */
     getParam(paramName: string): any;
+    /**
+     * updates the widget
+     */
     update(): any;
+    /**
+     * pipes the specified output to a
+     * destination data sink,
+     * the destination is returned to enable chaining
+     * @param name 
+     * @param dest 
+     */
     pipeOutput(name: string, dest: DataSink<any>): DataSink<any>;
+    /**
+     * gets the observable corresponding to the specified output,
+     * same as ```widget.outputs[name].observable```
+     * @param name 
+     */
     getOutputObservable(name: string): Observable<any>;
 }
 

--- a/src/core/widget/types.ts
+++ b/src/core/widget/types.ts
@@ -66,6 +66,7 @@ export interface WidgetModel extends DataSource<WidgetUpdateResult> {
     state: WidgetModelContext;
     inputs: {[name: string]: DataSink<any>},
     outputs: {[name: string]: DataSource<any>},
+    _outputsObservables: {[name: string]: Observable<any>};
     setInput(inputName: string, value: any): void;
     setInputs(inputs: {[name: string]: any}): void;
     getInput(inputName: string): any;

--- a/src/core/widget/types.ts
+++ b/src/core/widget/types.ts
@@ -1,4 +1,5 @@
 import { DataSink, DataSource } from '@/types';
+import { Observable } from 'rxjs';
 
 export enum WidgetArgDataType {
     Any = 'any',
@@ -63,6 +64,8 @@ export interface WidgetModelContext {
 export interface WidgetModel extends DataSource<WidgetUpdateResult> {
     opts: WidgetOpts;
     state: WidgetModelContext;
+    inputs: {[name: string]: DataSink<any>},
+    outputs: {[name: string]: DataSource<any>},
     setInput(inputName: string, value: any): void;
     setInputs(inputs: {[name: string]: any}): void;
     getInput(inputName: string): any;
@@ -71,6 +74,7 @@ export interface WidgetModel extends DataSource<WidgetUpdateResult> {
     getParam(paramName: string): any;
     update(): any;
     pipeOutput(name: string, dest: DataSink<any>): DataSink<any>;
+    getOutputObservable(name: string): Observable<any>;
 }
 
 export interface WidgetTemplateCreateArgs {

--- a/src/core/widget/widget-model.ts
+++ b/src/core/widget/widget-model.ts
@@ -18,8 +18,20 @@ export function createWidgetCreateFunction (opts: WidgetOpts)  {
                 this.state.inputs[name] = value;
                 this.update();
             },
+            setInputs (inputs) {
+                Object.keys(inputs).forEach(name => {
+                    this.state.inputs[name] = inputs[name];
+                });
+                this.update();
+            },
             setParam (name: string, value: any) {
                 this.state.params[name] = value;
+                this.update();
+            },
+            setParams (params) {
+                Object.keys(params).forEach(name => {
+                    this.state.params[name] = params[name];
+                });
                 this.update();
             },
             get observable () {

--- a/src/core/widget/widget-model.ts
+++ b/src/core/widget/widget-model.ts
@@ -1,5 +1,6 @@
 import {Subject} from 'rxjs';
-import { WidgetModel, WidgetOpts, WidgetModelContext, WidgetArgDataType, WidgetParams } from "./types";
+import { WidgetModel, WidgetOpts, WidgetModelContext, WidgetArgDataType, WidgetParams, WidgetUpdateResult } from "./types";
+import { DataSink } from 'types';
 
 export function createWidgetCreateFunction (opts: WidgetOpts)  {
     function create () {
@@ -25,8 +26,18 @@ export function createWidgetCreateFunction (opts: WidgetOpts)  {
                 return source;
             },
             update () {
-                const output = this.opts.onUpdate(this.state);
-                source.next(output);
+                const outputs = this.opts.onUpdate(this.state);
+                source.next(outputs);
+            },
+            pipe (dest: DataSink<any>): DataSink<any> {
+                source.subscribe(outputs => dest.next(outputs));
+                return dest;
+            },
+            pipeOutput (name: string, dest: DataSink<any>): DataSink<any> {
+                source.subscribe((outputs: WidgetUpdateResult) => {
+                    dest.next(outputs[name]);
+                });
+                return dest;
             }
         }
 

--- a/src/samples/widgets.ts
+++ b/src/samples/widgets.ts
@@ -5,7 +5,7 @@ const WIDGETS =
 const img = imsource.read();
 
 // define a custom widget template
-const Rotation = widgets.define('Rotation', {
+widgets.define('Rotation', {
     // define parameters for this widget
     params: {
         angle: {
@@ -40,16 +40,14 @@ const Rotation = widgets.define('Rotation', {
 });
 
 // create a widget instance from the template
-const rotation = Rotation.create();
+const widgetId = widgets.create('Rotation');
+const rotation = widgets.get(widgetId);
 
 // attach the widget to the image viewer
-rotation.pipeOutput('image', imviewer);
-
-// display the image widget
-widgets.add(rotation);
+rotation.outputs.image.pipe(imviewer);
 
 // set the loaded image as the widget input
-rotation.setInput('image', img);
+rotation.inputs.image.next(img);
 
 // To learn more about OpenCV for JS,
 // check out the tutorials at

--- a/src/samples/widgets.ts
+++ b/src/samples/widgets.ts
@@ -43,10 +43,7 @@ const Rotation = widgets.define('Rotation', {
 const rotation = Rotation.create();
 
 // attach the widget to the image viewer
-rotation.observable.subscribe(({ image }) => {
-    imviewer.show(image);
-    image.delete();
-});
+rotation.pipeOutput('image', imviewer);
 
 // display the image widget
 widgets.add(rotation);

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,4 +1,4 @@
-import { Observable, Observer } from 'rxjs';
+import { Observable, Observer, Subscription, NextObserver } from 'rxjs';
 import { WidgetManager } from '@/ui/widget-manager';
 
 export interface Editor {
@@ -29,6 +29,7 @@ export interface HtmlInputEvent extends Event {
 
 export interface DataSource<T> {
     readonly observable: Observable<T>;
+    subscribe (observer: NextObserver<T>): Subscription;
     pipe (dest: DataSink<T>): DataSink<T>;
 }
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -8,7 +8,7 @@ export interface Editor {
     setRunHandler(handler: (source: string) => void): void;
 }
 
-export interface ImageViewer {
+export interface ImageViewer extends DataSink<any> {
     show (mat: any): void;
 }
 
@@ -29,8 +29,9 @@ export interface HtmlInputEvent extends Event {
 
 export interface DataSource<T> {
     readonly observable: Observable<T>;
+    pipe (dest: DataSink<T>): DataSink<T>;
 }
 
 export interface DataSink<T> {
-    readonly observer: Observer<T>
+    next (value?: T): void;
 }

--- a/src/ui/image-viewer.ts
+++ b/src/ui/image-viewer.ts
@@ -18,4 +18,11 @@ export default class implements ImageViewer {
     show (mat: any) {
         cv.imshow(this.canvas.id, mat);
     }
+
+    next (mat: any) {
+        this.show(mat);
+        if (mat.delete) {
+            mat.delete();
+        }
+    }
 }


### PR DESCRIPTION
Addresses #27 

Adds improvements in the inputs and outputs API of widgets. This included changes made to `WidgetModel` as well as `DataSink` and `DataSource` interfaces.

- added a `widget.inputs` object which maps inputs to data sinks, allowing you to do something like `widget.inputs.image.next(img)`. This makes it possible to pipe a data source to a widget input or to pass the input to an observable.
- added a `widget.outputs` object which maps outputs to data sources, allowing you to do something like `widget.outputs.image.pipe(dest)`. This allows you to pipe outputs to data sinks or to use them as observables.
- you can also use the widget itself as a data source or observable via `widget.pipe(outputs)` or `widget.subscribe(observer)`. In this case the value is the entire outputs objects returned by `onUpdate(ctx)`
- the `DataSink` interface has been changed, it now only contains a `next` method
- `DataSource` has been changed, it now has `pipe` and `subscribe` methods, in addition to exposing an `observable`
- There are new `widget.setInputs(inputs: object)` and `setParams(params: object)` methods which allow you to set multiple inputs/params at a go
- `ImageViewer` now implements the `DataSink` interface. So you can pipe a widget output directly to the `imviewer`. The `imviewer`'s `next` implementation calls `.delete()` on the image matrix it receives to make sure memory is cleaned, assuming it will be used as the last sink in the pipeline.