### PR TITLE
Create root module

### DIFF
--- a/src/app.ts
+++ b/src/app.ts
@@ -1,4 +1,7 @@
 import { AppNewArgs } from '@/types';
+import { createWidgetTemplate } from '@/core/widget';
+
+const ROOT_MODULE = 'xaval';
 
 export default class App {
     args: AppNewArgs;
@@ -15,18 +18,30 @@ export default class App {
         this.args.editor.focus();
     }
 
+    getRootModule () {
+        return {
+            cv,
+            widgets: this.args.widgetManager,
+            core: {
+                widget: {
+                    createWidgetTemplate
+                },
+            },
+            io: {
+                imageViewer: this.args.imageViewer,
+                imageSource: this.args.imageSource,
+            }
+        }
+    }
+
     runCode (source: string) {
         const execute = Function(
-            'imsource',
-            'imviewer',
-            'widgets',
+            ROOT_MODULE,
             `"use strict";${source}`
         );
 
         return execute(
-            this.args.imageSource,
-            this.args.imageViewer,
-            this.args.widgetManager
+            this.getRootModule()
         );
     }
 }

--- a/src/samples/quick-intro.ts
+++ b/src/samples/quick-intro.ts
@@ -1,13 +1,14 @@
 const QUICK_INTRO = 
 `// Xaval is a playground for experimenting with computer vision using OpenCV
 
+const { imageSource, imageViewer } = xaval.io;
 // To get started, import an image from the bottom-left
-// Use \`imsource.read()\` to load the imported image into an OpenCV matrix
-const img = imsource.read();
+// Use \`imageSource.read()\` to load the imported image into an OpenCV matrix
+const img = imageSource.read();
 // Do some image processing and manipulation using OpenCV
 cv.cvtColor(img, img, cv.COLOR_RGBA2GRAY, 0);
-// Then, to display an image, use \`imviewer.show()\`
-imviewer.show(img);
+// Then, to display an image, use \`imageViewer.show()\`
+imageViewer.show(img);
 
 // don't forget to clean up the memory
 img.delete();

--- a/src/samples/widgets.ts
+++ b/src/samples/widgets.ts
@@ -3,7 +3,6 @@ const WIDGETS =
 
 const { widgets, io: { imageSource, imageViewer } } = xaval;
 
-
 // import an image from the import panel at the bottom right, then load it here
 const img = imageSource.read();
 

--- a/src/samples/widgets.ts
+++ b/src/samples/widgets.ts
@@ -1,8 +1,11 @@
 const WIDGETS =
 `// This example demonstrates how to create custom widgets in Xaval
 
+const { widgets, io: { imageSource, imageViewer } } = xaval;
+
+
 // import an image from the import panel at the bottom right, then load it here
-const img = imsource.read();
+const img = imageSource.read();
 
 // define a custom widget template
 widgets.define('Rotation', {
@@ -44,7 +47,7 @@ const widgetId = widgets.create('Rotation');
 const rotation = widgets.get(widgetId);
 
 // attach the widget to the image viewer
-rotation.outputs.image.pipe(imviewer);
+rotation.outputs.image.pipe(imageViewer);
 
 // set the loaded image as the widget input
 rotation.inputs.image.next(img);


### PR DESCRIPTION
Addresses #19 

Reorganises exposed objects in the xaval editor around a root `xaval` module.
At the moment it looks like:

```javascript
xaval = {
  cv,
  widgets,
  core: {
    widget: {
      createWidgetTemplate
    }
  },
  io: {
    imageViewer,
    imageSource
  }
}
```

This can change in the future as I figure out a better way of organising things.