### PR TITLE
Camera

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,7 @@ Interactive web-based playground for computer vision and image processing, usefu
 - You can import multiple images from your computer
 - Simple API for loading input images and displaying out images
 - Support for custom widgets and pipelines that control function parameters in real time
+- Easy API for working with video streams from a connected camera
 
 ## Planned Features
 
@@ -20,7 +21,7 @@ In no particular order, here are some of the features planned:
 - Support for Tensorflow.js
 - Supporting for importing other file types besides images
 - Load images/videos from the web
-- Video and Webcam support
+- Support for importing videos
 - Background code execution
 - Console/Stdout emulator
 - Multiple code cells

--- a/src/app.ts
+++ b/src/app.ts
@@ -30,6 +30,7 @@ export default class App {
             io: {
                 imageViewer: this.args.imageViewer,
                 files: this.args.files,
+                cameras: this.args.cameras
             }
         }
     }

--- a/src/core/video/index.ts
+++ b/src/core/video/index.ts
@@ -1,0 +1,4 @@
+import VideoStream from './video-stream';
+
+export * from './types';
+export { VideoStream };

--- a/src/core/video/types.ts
+++ b/src/core/video/types.ts
@@ -33,7 +33,8 @@ export interface VideoStreamParams {
      */
     fps: number;
     /**
-     * whether the stream should start automatically
+     * indicates whether the video stream should be started
+     * automatically by its video model
      */
-    autoStart: false;
+    autoStart?: boolean;
 }

--- a/src/core/video/types.ts
+++ b/src/core/video/types.ts
@@ -1,0 +1,22 @@
+import { DataSource } from '@/types';
+
+export interface VideoModel {
+    /**
+     * reads the current image frame the video
+     * @return {cv.Mat} frame image
+     */
+    read(): any;
+
+    /**
+     * gets a stream from the video, that
+     * can be piped to a data source
+     */
+    getStream(params: VideoStreamParams): DataSource<any>;
+}
+
+export interface VideoStreamParams {
+    /**
+     * frame rate of the video stream
+     */
+    fps: number;
+}

--- a/src/core/video/types.ts
+++ b/src/core/video/types.ts
@@ -2,10 +2,23 @@ import { DataSource } from '@/types';
 
 export interface VideoModel {
     /**
-     * reads the current image frame the video
-     * @return {cv.Mat} frame image
+     * the height of the video
      */
-    read(): any;
+    readonly height: number;
+
+    /**
+     * the width of the video;
+     */
+    readonly width: number;
+
+    /**
+     * reads the current image frame the video
+     * @param {cv.Mat} dest matrix object where to store the image,
+     * if not provided, a new matrix is created
+     * @return {cv.Mat} frame image
+     * if `dest` was provided, then this will be the same object
+     */
+    read(dest?: any): any;
 
     /**
      * gets a stream from the video, that

--- a/src/core/video/types.ts
+++ b/src/core/video/types.ts
@@ -32,4 +32,8 @@ export interface VideoStreamParams {
      * frame rate of the video stream
      */
     fps: number;
+    /**
+     * whether the stream should start automatically
+     */
+    autoStart: false;
 }

--- a/src/core/video/types.ts
+++ b/src/core/video/types.ts
@@ -1,6 +1,6 @@
 import { DataSource } from '@/types';
 
-export interface VideoModel {
+export interface VideoSource {
     /**
      * the height of the video
      */

--- a/src/core/video/video-stream.ts
+++ b/src/core/video/video-stream.ts
@@ -1,0 +1,68 @@
+import { Subject, NextObserver, Subscription } from 'rxjs';
+import { DataSink, DataSource } from '@/types';
+import { VideoStreamParams, VideoModel } from './types';
+
+export default class implements DataSource<any> {
+    private _source: Subject<any>;
+    private _params: VideoStreamParams;
+    private _streaming: boolean = false;
+    private _video: VideoModel;
+
+    constructor (video: VideoModel, params: VideoStreamParams) {
+        this._source = new Subject();
+        this._params = { ...params };
+        this._video = video;
+    }
+    
+    /**
+     * whether or not the stream is currently running
+     */
+    get streaming () {
+        return this._streaming;
+    }
+
+    get observable () {
+        return this._source;
+    }
+
+    /**
+     * starts the video stream
+     */
+    start () {
+        if (this._streaming) {
+            return;
+        }
+        this._streaming = true;
+        this.loop();
+    }
+
+    /**
+     * stops the video stream
+     */
+    stop () {
+        if (!this._streaming) {
+            return;
+        }
+        this._streaming = false;
+    }
+
+    private loop () {
+        if (!this._streaming) {
+            return;
+        }
+        const started = Date.now();
+        const mat = this._video.read();
+        this._source.next(mat);
+        const delay = 1000 / this._params.fps - (Date.now() - started);
+        setTimeout(() => this.loop(), delay);
+    }
+
+    pipe (dest: DataSink<any>): DataSink<any> {
+        this._source.subscribe(outputs => dest.next(outputs));
+        return dest;
+    }
+
+    subscribe (observer: NextObserver<any>): Subscription {
+        return this._source.subscribe(observer);
+    }
+}

--- a/src/core/video/video-stream.ts
+++ b/src/core/video/video-stream.ts
@@ -2,7 +2,7 @@ import { Subject, NextObserver, Subscription } from 'rxjs';
 import { DataSink, DataSource } from '@/types';
 import { VideoStreamParams, VideoModel } from './types';
 
-export default class implements DataSource<any> {
+export default class VideoStream implements DataSource<any> {
     private _source: Subject<any>;
     private _params: VideoStreamParams;
     private _streaming: boolean = false;
@@ -51,8 +51,8 @@ export default class implements DataSource<any> {
             return;
         }
         const started = Date.now();
-        const mat = this._video.read();
-        this._source.next(mat);
+        const frame = this._video.read();
+        this._source.next(frame);
         const delay = 1000 / this._params.fps - (Date.now() - started);
         setTimeout(() => this.loop(), delay);
     }

--- a/src/core/video/video-stream.ts
+++ b/src/core/video/video-stream.ts
@@ -1,14 +1,14 @@
 import { Subject, NextObserver, Subscription } from 'rxjs';
 import { DataSink, DataSource } from '@/types';
-import { VideoStreamParams, VideoModel } from './types';
+import { VideoStreamParams, VideoSource } from './types';
 
 export default class VideoStream implements DataSource<any> {
     private _source: Subject<any>;
     private _params: VideoStreamParams;
     private _streaming: boolean = false;
-    private _video: VideoModel;
+    private _video: VideoSource;
 
-    constructor (video: VideoModel, params: VideoStreamParams) {
+    constructor (video: VideoSource, params: VideoStreamParams) {
         this._source = new Subject();
         this._params = { ...params };
         this._video = video;

--- a/src/core/video/video-stream.ts
+++ b/src/core/video/video-stream.ts
@@ -12,9 +12,10 @@ export default class VideoStream implements DataSource<any> {
         this._source = new Subject();
         this._params = { ...params };
         this._video = video;
-        if (this._params.autoStart) {
-            this.start();
-        }
+    }
+
+    get params () {
+        return this._params;
     }
     
     /**

--- a/src/core/video/video-stream.ts
+++ b/src/core/video/video-stream.ts
@@ -12,6 +12,9 @@ export default class VideoStream implements DataSource<any> {
         this._source = new Subject();
         this._params = { ...params };
         this._video = video;
+        if (this._params.autoStart) {
+            this.start();
+        }
     }
     
     /**

--- a/src/init.ts
+++ b/src/init.ts
@@ -3,7 +3,8 @@ import {
     Editor,
     FileLibrary,
     ImageViewer,
-    WidgetManager
+    WidgetManager,
+    CameraManager
 } from './ui';
 import './ui/app.css';
 
@@ -26,12 +27,14 @@ export default function init () {
     const imageViewer = new ImageViewer(document.querySelector('#imageViewer'));
     const files = new FileLibrary(document.querySelector('#files'));
     const widgetManager = new WidgetManager(document.querySelector('#main'));
+    const cameras = new CameraManager();
 
     const app = new App({
         editor,
         files,
         imageViewer,
-        widgetManager
+        widgetManager,
+        cameras
     });
 
     return app;

--- a/src/samples/camera.ts
+++ b/src/samples/camera.ts
@@ -4,8 +4,6 @@ export default
 const camera = cameras.getDefault();
 const stream = camera.getStream({ fps: 30 });
 stream.pipe(imageViewer);
-camera.request().then(() => {
-  stream.start();
-});
+camera.start();
 
 `;

--- a/src/samples/camera.ts
+++ b/src/samples/camera.ts
@@ -1,0 +1,11 @@
+export default
+`const { cameras, imageViewer } = xaval.io;
+
+const camera = cameras.getDefault();
+const stream = camera.getStream({ fps: 30 });
+stream.pipe(imageViewer);
+camera.request().then(() => {
+  stream.start();
+});
+
+`;

--- a/src/samples/edge-detection.ts
+++ b/src/samples/edge-detection.ts
@@ -1,0 +1,56 @@
+export default
+`const { cameras, imageViewer } = xaval.io;
+const { widgets } = xaval;
+
+// start camera feed
+const camera = cameras.getDefault();
+camera.start();
+
+// create edge detection widget
+widgets.define('EdgeDetection', {
+  params: {
+    threshold1: {
+      type: 'number',
+      min: 1,
+      max: 500,
+      initial: 50
+    },
+    threshold2: {
+      type: 'number',
+      min: 1,
+      max: 500,
+      initial: 100
+    },
+    apertureSize: {
+      type: 'number',
+      min: 1,
+      max: 20,
+      initial: 3
+    },
+    l2Gradient: {
+      type: 'number',
+      min: 0,
+      max: 1,
+      initial: 0
+    }
+  },
+  inputs: ['image'],
+  outputs: ['edges'],
+  onUpdate (ctx) {
+    const { image } = ctx.inputs;
+    const { threshold1, threshold2, apertureSize, l2Gradient } = ctx.params;
+    const dst = new cv.Mat();
+    cv.cvtColor(image, dst, cv.COLOR_RGBA2GRAY, 0);
+    cv.Canny(dst, dst, threshold1, threshold2, apertureSize, Boolean(l2Gradient));
+    return { edges: dst };
+  }
+});
+
+const widgetId = widgets.create('EdgeDetection');
+const edgeWidget = widgets.get(widgetId);
+
+// feed camera stream to widget and display output
+const stream = camera.getStream({ fps: 30 });
+stream.pipe(edgeWidget.inputs.image);
+edgeWidget.outputs.edges.pipe(imageViewer);
+`;

--- a/src/samples/edge-detection.ts
+++ b/src/samples/edge-detection.ts
@@ -1,6 +1,5 @@
 export default
-`const { cameras, imageViewer } = xaval.io;
-const { widgets } = xaval;
+`const { widgets, io: { cameras, imageViewer } } = xaval;
 
 // start camera feed
 const camera = cameras.getDefault();

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,6 +1,6 @@
 import { Observable, Observer, Subscription, NextObserver } from 'rxjs';
-import { WidgetManager } from '@/ui/widget-manager';
 import { FileLibrary } from '@/core/files';
+import { CameraManager, WidgetManager } from '@/ui';
 
 export interface Editor {
     source: string;
@@ -22,6 +22,7 @@ export interface AppNewArgs {
     imageViewer: ImageViewer;
     files: FileLibrary;
     widgetManager: WidgetManager;
+    cameras: CameraManager;
 }
 
 export interface HtmlInputEvent extends Event {

--- a/src/ui/camera/camera-manager.ts
+++ b/src/ui/camera/camera-manager.ts
@@ -1,0 +1,26 @@
+import { Camera } from '.';
+
+/**
+ * provides access to the camera resource
+ */
+export class CameraManager {
+    private _default: Camera;
+
+    /**
+     * gets the default camera
+     */
+    getDefault () {
+        if (!this._default) {
+            this._default = new Camera();
+        }
+        return this._default;
+    }
+
+    /**
+     * gets camera with specified constraints
+     * @param constraints camera constraints
+     */
+    getWithConstraints (constraints: MediaStreamConstraints) {
+        return new Camera(constraints);
+    }
+}

--- a/src/ui/camera/camera.ts
+++ b/src/ui/camera/camera.ts
@@ -1,6 +1,6 @@
-import { VideoModel, VideoStream, VideoStreamParams } from '@/core/video';
+import { VideoSource, VideoStream, VideoStreamParams } from '@/core/video';
 
-export class Camera implements VideoModel {
+export class Camera implements VideoSource {
     private _video: HTMLVideoElement;
     private _capture: any;
     private _cameraStream: MediaStream;

--- a/src/ui/camera/camera.ts
+++ b/src/ui/camera/camera.ts
@@ -1,0 +1,66 @@
+import { VideoModel, VideoStream, VideoStreamParams } from '@/core/video';
+
+export class Camera implements VideoModel {
+    private _video: HTMLVideoElement;
+    private _capture: any;
+    private _cameraStream: MediaStream;
+    private _stream: VideoStream;
+    private _constraints: MediaStreamConstraints;
+
+    constructor (constraints: MediaStreamConstraints = { video: true, audio: false }) {
+        this._video = document.createElement('video');
+        this._constraints = constraints;
+    }
+
+    /**
+     * requests access to the camera
+     */
+    request () {
+        if (this._cameraStream) {
+            return Promise.resolve();
+        }
+        return new Promise((resolve, reject) => {
+            navigator.mediaDevices.getUserMedia(this._constraints)
+            .then(camStream => {
+                this._video.srcObject = camStream;
+                this._cameraStream = camStream;
+                this._video.addEventListener('canplay', () => {
+                    this.onVideoReady();
+                    resolve();
+                });
+            })
+            .catch(err => {
+                alert(`Error: ${err}`);
+                reject(err);
+            });
+        });
+    }
+    
+    private onVideoReady () {
+        this._video.width = this._video.videoWidth;
+        this._video.height = this._video.videoHeight;
+        this._capture = new cv.VideoCapture(this._video);
+        this._video.play();
+    }
+
+    get width () {
+        return this._video.width;
+    }
+
+    get height () {
+        return this._video.height;
+    }
+
+    read (dest?: any) {
+        dest = dest ||  new cv.Mat(this.height, this.width, cv.CV_8UC4);
+        this._capture.read(dest);
+        return dest;
+    }
+
+    getStream (params: VideoStreamParams) {
+        if (!this._stream) {
+            this._stream = new VideoStream(this, params);
+        }
+        return this._stream;
+    }
+}

--- a/src/ui/camera/camera.ts
+++ b/src/ui/camera/camera.ts
@@ -13,7 +13,6 @@ export class Camera implements VideoModel {
         this._video = document.createElement('video');
         this._constraints = constraints;
         this._onPlayHandler = this.onVideoPlaying.bind(this);
-        this._video.addEventListener('play', this._onPlayHandler);
     }
 
     /**
@@ -46,10 +45,11 @@ export class Camera implements VideoModel {
         this._video.height = this._video.videoHeight;
         this._capture = new cv.VideoCapture(this._video);
         this._video.play();
+        this._video.addEventListener('play', this._onPlayHandler);
     }
 
     private onVideoPlaying () {
-        if (this._stream && this._stream.params.autoStart) {
+        if (this._stream && this._stream.params.autoStart && !this._stream.streaming) {
             this._stream.start();
         }
     }
@@ -89,6 +89,9 @@ export class Camera implements VideoModel {
         if (!this._stream) {
             params = { autoStart: true, ...params };
             this._stream = new VideoStream(this, params);
+            if (this._cameraStream && params.autoStart) {
+                this._stream.start();
+            }
         }
         return this._stream;
     }
@@ -104,6 +107,7 @@ export class Camera implements VideoModel {
         }
         if (this._cameraStream) {
             this._cameraStream.getVideoTracks()[0].stop();
+            this._cameraStream = null;
         }
         if (this._stream) {
             this._stream.stop();

--- a/src/ui/camera/index.ts
+++ b/src/ui/camera/index.ts
@@ -1,0 +1,2 @@
+export { Camera } from './camera';
+export { CameraManager } from './camera-manager';

--- a/src/ui/editor/editor.ts
+++ b/src/ui/editor/editor.ts
@@ -1,5 +1,5 @@
 import { Editor } from '@/types';
-import INITIAL_CODE from '@/samples/camera';
+import INITIAL_CODE from '@/samples/edge-detection';
 import { EditorProvider } from './types';
 import { createAceEditor } from './ace';
 

--- a/src/ui/editor/editor.ts
+++ b/src/ui/editor/editor.ts
@@ -1,5 +1,5 @@
 import { Editor } from '@/types';
-import INITIAL_CODE from '@/samples/widgets';
+import INITIAL_CODE from '@/samples/camera';
 import { EditorProvider } from './types';
 import { createAceEditor } from './ace';
 

--- a/src/ui/file-lib/file-lib-view.ts
+++ b/src/ui/file-lib/file-lib-view.ts
@@ -47,7 +47,6 @@ export default class FileLibView implements FileLibrary {
     }
 
     readImage (name: string): any {
-        console.log(this.files);
         const file = this.files[name];
         // TODO: ensure file is of type image
         return file && cv.imread(file.source.image);

--- a/src/ui/index.ts
+++ b/src/ui/index.ts
@@ -10,3 +10,4 @@ export {
 
 export { WidgetManager } from './widget-manager';
 export { WidgetView } from './widget-view';
+export { Camera, CameraManager } from './camera';

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -5,7 +5,7 @@
         "sourceMap": true,
         "noImplicitAny": true,
         "module": "es6",
-        "target": "es5",
+        "target": "es6",
         "allowJs": true,
         "moduleResolution": "node",
         "paths": {


### PR DESCRIPTION
Addresses #9

This PR adds camera support.

It exposes ` CameraManager` via `xaval.io.cameras` which allows you to access the user's connected camera(s).

It has 2 methods:
- `cameras.getDefault()`: which requests a muted video stream from the default camera from the browser i.e. it passes the constraints `{ video: true, audio: false }` to `navigator.mediaDevices.getUserMedia()`.
- `cameras.getWithConstraints(constraints)`: which allow you to specify the constraints passed to the browser API

Both methods return a `Camera` instance, which provides an easy API for working with the camera. To start using the camera, you should call `camera.start()` which requests permission from the user, and if granted, obtains the video stream. `camera.start()` returns a promise which resolves if camera access is provided, and rejects if an error occurs (e.g. permission denied).

The `Camera` implements the `VideoSource` interface, which exposes the `read()` method, for reading the current image frame, and `getStream(params)` which returns a `VideoStream`.

The `VideoStream` is a `DataSource` which streams frames from the video at a specified rate. `VideoStream` exposes methods `start()` and `stop()` in addition to the standard `DataSource` methods. If the `camera.getStream(params)` with `params.autoStart = true`, the camera instance will start the video stream automatically when its receiving video data.

Example:
```javascript
const camera = xaval.io.cameras.getDefault();
const stream = camera.getStream({ fps: 30 });
stream.pipe(xaval.io.imageViewer);
camera.start();
```

2 new code samples have been added to demonstrate the user of cameras: `camera` and `edge-detection`.