### PR TITLE
Samples menu

### DIFF
--- a/src/app.ts
+++ b/src/app.ts
@@ -17,6 +17,7 @@ export default class App {
 
         this.args.samples.onSampleSelected(code => {
             this.args.editor.source = code;
+            this.args.editor.focus();
         });
 
         this.args.editor.focus();

--- a/src/app.ts
+++ b/src/app.ts
@@ -15,6 +15,10 @@ export default class App {
             console.log('Code result', res);
         });
 
+        this.args.samples.onSampleSelected(code => {
+            this.args.editor.source = code;
+        });
+
         this.args.editor.focus();
     }
 

--- a/src/init.ts
+++ b/src/init.ts
@@ -4,8 +4,10 @@ import {
     FileLibrary,
     ImageViewer,
     WidgetManager,
-    CameraManager
+    CameraManager,
+    SampleManager
 } from './ui';
+import * as codeSamples from '@/samples';
 import './ui/app.css';
 
 
@@ -28,13 +30,21 @@ export default function init () {
     const files = new FileLibrary(document.querySelector('#files'));
     const widgetManager = new WidgetManager(document.querySelector('#main'));
     const cameras = new CameraManager();
+    const samples = new SampleManager(document.querySelector('#samplesMenu'));
+    samples.addSamples({
+        'Quick Intro': codeSamples.QUICK_INTRO,
+        'Widgets': codeSamples.WIDGETS,
+        'Camera': codeSamples.CAMERA,
+        'Edge Detection': codeSamples.EDGE_DETECTION
+    });
 
     const app = new App({
         editor,
         files,
         imageViewer,
         widgetManager,
-        cameras
+        cameras,
+        samples
     });
 
     return app;

--- a/src/samples/camera.ts
+++ b/src/samples/camera.ts
@@ -1,9 +1,16 @@
 export default
 `const { cameras, imageViewer } = xaval.io;
 
+// get the default camera from the browser
 const camera = cameras.getDefault();
+
+// create a 30 fps stream of the video from the camera
 const stream = camera.getStream({ fps: 30 });
 stream.pipe(imageViewer);
+
+// request for access and start camera feed
 camera.start();
 
+// when you're done, you can stop the camera and dispose of resources
+// camera.stop();
 `;

--- a/src/samples/edge-detection.ts
+++ b/src/samples/edge-detection.ts
@@ -22,8 +22,9 @@ widgets.define('EdgeDetection', {
     },
     apertureSize: {
       type: 'number',
-      min: 1,
-      max: 20,
+      min: 3,
+      max: 7,
+      step: 2,
       initial: 3
     },
     l2Gradient: {

--- a/src/samples/empty.ts
+++ b/src/samples/empty.ts
@@ -1,0 +1,4 @@
+export default
+`// write your code here
+// check out the code samples if you need help getting started
+`;

--- a/src/samples/index.ts
+++ b/src/samples/index.ts
@@ -1,0 +1,11 @@
+import CAMERA from './camera';
+import EDGE_DETECTION from './edge-detection';
+import QUICK_INTRO from './quick-intro';
+import WIDGETS from './widgets';
+
+export {
+    CAMERA,
+    EDGE_DETECTION,
+    QUICK_INTRO,
+    WIDGETS
+};

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,6 +1,6 @@
 import { Observable, Observer, Subscription, NextObserver } from 'rxjs';
 import { FileLibrary } from '@/core/files';
-import { CameraManager, WidgetManager } from '@/ui';
+import { CameraManager, WidgetManager, SampleManager } from '@/ui';
 
 export interface Editor {
     source: string;
@@ -23,6 +23,7 @@ export interface AppNewArgs {
     files: FileLibrary;
     widgetManager: WidgetManager;
     cameras: CameraManager;
+    samples: SampleManager;
 }
 
 export interface HtmlInputEvent extends Event {

--- a/src/ui/app.css
+++ b/src/ui/app.css
@@ -1,7 +1,7 @@
 body {
     padding: 0;
     margin: 0;
-    font-family: Montserrat, sans-serif;
+    font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, Cantarell, 'Open Sans', 'Helvetica Neue', sans-serif;
 }
 
 .btn {
@@ -42,8 +42,63 @@ body {
     margin-right: 100px;
 }
 
-#header .header-main {
+#header .nav-menu {
     flex-grow: 1;
+    display: flex;
+    height: 100%;
+    flex-direction: row;
+    list-style: none;
+}
+
+.nav-menu .nav-item {
+    padding: 5px 10px;
+    height: 100%;
+    box-sizing: border-box;
+    display: flex;
+    align-items: center;
+    font-size: 0.8em;
+    width: 90px;
+    justify-content: center; 
+}
+
+.nav-item:hover {
+    cursor: pointer;
+    border-bottom: 2px solid #3f8060;
+    position: relative;
+    bottom: -1px;
+}
+
+.nav-submenu {
+    position: absolute;
+    display: none;
+    top: 54px;
+    left: 0px;
+    border-radius: 2px;
+}
+
+.nav-item:hover>.nav-submenu {
+    display: block;
+    z-index: 10;
+    background: #fff;
+    border-bottom: none;
+    list-style: none;
+    padding: 0px;
+    box-shadow: 0px 0px 8px;
+}
+
+.nav-sub-item {
+    padding: 10px;
+    width: 150px;
+    box-sizing: border-box;
+    border-bottom: 1px solid #d8e8e0;
+}
+
+.nav-sub-item:last-child {
+    border-bottom: none;
+}
+
+.nav-sub-item:hover {
+    background-color: #d8e8e0;
 }
 
 #status {

--- a/src/ui/editor/ace.ts
+++ b/src/ui/editor/ace.ts
@@ -8,5 +8,16 @@ export function createAceEditor (domEl: HTMLElement, opts: EditorInitOpts): Edit
     editor.session.setMode('ace/mode/javascript');
     editor.setShowPrintMargin(false);
     editor.clearSelection();
-    return editor;
+    return {
+        focus () {
+            editor.focus();
+        },
+        setValue (code: string) {
+            editor.setValue(code);
+            editor.clearSelection();
+        },
+        getValue (): string {
+            return editor.getValue();
+        }
+    };
 }

--- a/src/ui/editor/editor.ts
+++ b/src/ui/editor/editor.ts
@@ -27,6 +27,10 @@ export default class implements Editor {
         return this.editor.getValue();
     }
 
+    set source (code: string) {
+        this.editor.setValue(code);
+    }
+
     focus () {
         this.editor.focus();
     }

--- a/src/ui/editor/editor.ts
+++ b/src/ui/editor/editor.ts
@@ -1,5 +1,5 @@
 import { Editor } from '@/types';
-import INITIAL_CODE from '@/samples/edge-detection';
+import INITIAL_CODE from '@/samples/empty';
 import { EditorProvider } from './types';
 import { createAceEditor } from './ace';
 

--- a/src/ui/editor/types.ts
+++ b/src/ui/editor/types.ts
@@ -1,5 +1,6 @@
 export interface EditorProvider {
     getValue (): string;
+    setValue (code: string): any;
     focus (): void;
 }
 

--- a/src/ui/index.html
+++ b/src/ui/index.html
@@ -3,7 +3,6 @@
 <head lang="en">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Xaval</title>
-    <link href="https://fonts.googleapis.com/css?family=Nunito" rel="stylesheet">
     <link rel="stylesheet" href="https://use.fontawesome.com/releases/v5.0.12/css/all.css" integrity="sha384-G0fIWCsCzJIMAVNQPfjH08cyYaUtMwjJwqiRKxxE/rx96Uroj1BtIQ6MLJuheaO9" crossorigin="anonymous">
 </head>
 <body>

--- a/src/ui/index.html
+++ b/src/ui/index.html
@@ -3,7 +3,7 @@
 <head lang="en">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Xaval</title>
-    <link href="https://fonts.googleapis.com/css?family=Montserrat" rel="stylesheet">
+    <link href="https://fonts.googleapis.com/css?family=Nunito" rel="stylesheet">
     <link rel="stylesheet" href="https://use.fontawesome.com/releases/v5.0.12/css/all.css" integrity="sha384-G0fIWCsCzJIMAVNQPfjH08cyYaUtMwjJwqiRKxxE/rx96Uroj1BtIQ6MLJuheaO9" crossorigin="anonymous">
 </head>
 <body>
@@ -13,6 +13,17 @@
         <div class="header-main">
             <button id="runButton" class="btn"><i class="fas fa-play"></i> Run</button>
         </div>
+        <ul class="nav-menu">
+            <li class="nav-item">
+                <span>Samples</span>
+                <ul class="nav-submenu">
+                    <li class="nav-sub-item">Sample 1</li>
+                    <li class="nav-sub-item">Sample 2</li>
+                    <li class="nav-sub-item">Sample 3</li>
+                </ul>
+            </li>
+            <li class="nav-item">Menu 2</li>
+        </ul>
         <div id="status">OpenCV.js is loading...</div>
     </header>
     <div id="main">

--- a/src/ui/index.html
+++ b/src/ui/index.html
@@ -16,13 +16,8 @@
         <ul class="nav-menu">
             <li class="nav-item">
                 <span>Samples</span>
-                <ul id="samplesMenu" class="nav-submenu">
-                    <li class="nav-sub-item">Sample 1</li>
-                    <li class="nav-sub-item">Sample 2</li>
-                    <li class="nav-sub-item">Sample 3</li>
-                </ul>
+                <ul id="samplesMenu" class="nav-submenu"></ul>
             </li>
-            <li class="nav-item">Menu 2</li>
         </ul>
         <div id="status">OpenCV.js is loading...</div>
     </header>

--- a/src/ui/index.html
+++ b/src/ui/index.html
@@ -16,7 +16,7 @@
         <ul class="nav-menu">
             <li class="nav-item">
                 <span>Samples</span>
-                <ul class="nav-submenu">
+                <ul id="samplesMenu" class="nav-submenu">
                     <li class="nav-sub-item">Sample 1</li>
                     <li class="nav-sub-item">Sample 2</li>
                     <li class="nav-sub-item">Sample 3</li>

--- a/src/ui/index.ts
+++ b/src/ui/index.ts
@@ -11,3 +11,4 @@ export {
 export { WidgetManager } from './widget-manager';
 export { WidgetView } from './widget-view';
 export { Camera, CameraManager } from './camera';
+export { SampleManager } from './samples';

--- a/src/ui/samples/index.ts
+++ b/src/ui/samples/index.ts
@@ -1,0 +1,1 @@
+export { SampleManager } from './sample-manager';

--- a/src/ui/samples/sample-manager.ts
+++ b/src/ui/samples/sample-manager.ts
@@ -1,0 +1,55 @@
+
+/**
+ * manages list of pre-loaded code samples available to the user
+ */
+export class SampleManager {
+    private _el: HTMLElement;
+    private _sampleHandler: SampleHandler;
+
+    constructor (el: HTMLElement) {
+        this._el = el;
+    }
+
+    /**
+     * register handler that will be called
+     * when a sample is selected from the menu
+     * @param handler 
+     */
+    onSampleSelected (handler: SampleHandler) {
+        this._sampleHandler = handler;
+    }
+
+    /**
+     * adds all samples in the specified map
+     * @param samples mapping of sample names to their source codes
+     */
+    addSamples (samples: SamplePairs) {
+        Object.keys(samples).map(name => {
+            const code = samples[name];
+            this.addSample(name, code);
+        });
+    }
+
+    /**
+     * add sample code to the list
+     * @param name displayed name of the sample
+     * @param code source code of the sample
+     */
+    addSample (name: string, code: string) {
+        const item = document.createElement('li');
+        item.className = 'nav-sub-item';
+        item.textContent = name;
+        item.addEventListener('click', () => {
+            this._sampleHandler && this._sampleHandler(code);
+        });
+        this._el.appendChild(item);
+    }
+}
+
+interface SampleHandler {
+    (sample: string): any;
+}
+
+interface SamplePairs {
+    [name: string]: string;
+}


### PR DESCRIPTION
Addresses #36 

Adds a drop down menu in the header for selecting code samples.

New samples can now be easily added to the menu via the `SampleManager` instance that's passed to the `App` constructor args.

One thing worth noting is that the samples as loaded into string variables, which means the full samples source codes are packaged as-is in the app bundle, this might lead to increased app bundle size if there are many large code samples.