### PR TITLE
Display widget id

### DIFF
--- a/src/samples/edge-detection.ts
+++ b/src/samples/edge-detection.ts
@@ -44,8 +44,7 @@ widgets.define('EdgeDetection', {
   }
 });
 
-const widgetId = widgets.create('EdgeDetection');
-const edgeWidget = widgets.get(widgetId);
+const edgeWidget = widgets.create('EdgeDetection');
 
 // feed camera stream to widget and display output
 const stream = camera.getStream({ fps: 30 });

--- a/src/samples/widgets.ts
+++ b/src/samples/widgets.ts
@@ -43,8 +43,7 @@ widgets.define('Rotation', {
 });
 
 // create a widget instance from the template
-const widgetId = widgets.create('Rotation');
-const rotation = widgets.get(widgetId);
+const rotation = widgets.create('Rotation');
 
 // attach the widget to the image viewer
 rotation.outputs.image.pipe(imageViewer);

--- a/src/ui/app.css
+++ b/src/ui/app.css
@@ -239,13 +239,28 @@ body {
     display: none;
 }
 
-.widget-title {
+.widget-header {
     padding: 3px 10px;
     background-color: #f7f7f7;
-    font-size: 0.8em;
-    font-weight: bold;
-    color: #848080;
     border-bottom: 1px solid #d8d8d8;
+    display: flex;
+    flex-direction: row;
+    justify-content: space-between;
+    align-items: center;
+}
+
+.widget-title {
+    color: #848080;
+    font-size: 0.8em;
+}
+
+.widget-id {
+    margin-left: 10px;
+    font-size: 0.6em;
+    font-style: italic;
+    font-weight: normal;
+    color: #afadad;
+    
 }
 
 .widget-content {

--- a/src/ui/widget/widget-manager.ts
+++ b/src/ui/widget/widget-manager.ts
@@ -39,13 +39,14 @@ export class WidgetManager {
     /**
      * creates a new widget based on the specified template
      * and adds it to the widget manager then displays it.
-     * Returns the id of the widget
+     * Returns the the widget
      * @param templateName name of a registered template
      */
-    public create (templateName: string): string {
+    public create (templateName: string): WidgetModel {
         const template = this.templates[templateName];
         const widget = template.create();
-        return this.add(widget);
+        this.add(widget);
+        return widget;
     }
 
     /**

--- a/src/ui/widget/widget-manager.ts
+++ b/src/ui/widget/widget-manager.ts
@@ -82,7 +82,7 @@ export class WidgetManager {
     public add (widget: WidgetModel): string {
         const view = new WidgetView(widget);
         const widgetId = `widget${this.nextWidgetId}`;
-        view.el.id = widgetId;
+        view.setId(widgetId);
         this.nextWidgetId += 1;
         this.el.appendChild(view.el);
         this.widgets[widgetId] = view;

--- a/src/ui/widget/widget-view.ts
+++ b/src/ui/widget/widget-view.ts
@@ -7,9 +7,15 @@ import { createCheckbox, createSlider, createSelect, createText } from './contro
 export class WidgetView {
     readonly el: HTMLElement;
     readonly model: WidgetModel;
+
     constructor (model: WidgetModel) {
         this.el = createHtml(model);
         this.model = model;
+    }
+
+    setId (id: string) {
+        this.el.id = id;
+        this.el.querySelector('.widget-id').textContent = `#${id}`;
     }
 }
 
@@ -19,7 +25,10 @@ interface WidgetHtmlElement extends HTMLDivElement {
 
 function createHtml (model: WidgetModel) {
     const tpl = 
-    `<div class="widget-title">${model.opts.name}</div>
+    `<div class="widget-header">
+        <span class="widget-title">${model.opts.name}</span>
+        <span class="widget-id"></span>
+    </div>
     <div class="widget-content">
         <div class="params-container">
         </div>
@@ -35,7 +44,7 @@ function createHtml (model: WidgetModel) {
         const control = createParamControl(paramName, model);
         paramContainer.appendChild(control);
     }
-    const header = <HTMLDivElement>node.querySelector('.widget-title');
+    const header = <HTMLDivElement>node.querySelector('.widget-header');
     header.draggable = true;
     header.ondragstart = (ev) => {
         ev.dataTransfer.setData('id', node.id);


### PR DESCRIPTION
Addresses #24 

Widgets now display their ids on the header.
Since now the user can tell what the widget id is, I've made a breaking change change to the `WidgetManager` API.

Now `WidgetManager.create()` returns the created widget and not its widget id. This was done to avoid extra code (one statement to create the widget, then another to get it by its id).
