### PR TITLE
Fix file lib bugs

### DIFF
--- a/src/ui/file-lib/file-lib-view.ts
+++ b/src/ui/file-lib/file-lib-view.ts
@@ -54,8 +54,11 @@ export default class FileLibView implements FileLibrary {
 
     rename(oldName: string, newName: string) {
         const file = this.files[oldName];
+        if (!(oldName in this.files)) {
+            alert(`The file '${oldName}' was not found.`);
+            return;
+        }
         if (newName in this.files) {
-            console.log('new', newName, this.files);
             alert(`There's already an imported file called '${newName}'.`);
             file.source.name = oldName;
             return;

--- a/src/ui/file-lib/file-lib-view.ts
+++ b/src/ui/file-lib/file-lib-view.ts
@@ -31,6 +31,10 @@ export default class FileLibView implements FileLibrary {
     addImage (fileUrl: string, filename: string = '') {
         const id = this.nextId();
         const name = filename || id;
+        if (name in this.files) {
+            alert(`There's already an imported file called '${name}'.`);
+            return;
+        }
         const source = new ImageSource(fileUrl, name);
         source.el.id = id;
         const file: FileSource = {

--- a/src/ui/file-lib/file-lib-view.ts
+++ b/src/ui/file-lib/file-lib-view.ts
@@ -31,7 +31,7 @@ export default class FileLibView implements FileLibrary {
     addImage (fileUrl: string, filename: string = '') {
         const id = this.nextId();
         const name = filename || id;
-        const source = new ImageSource(fileUrl, id)
+        const source = new ImageSource(fileUrl, name);
         source.el.id = id;
         const file: FileSource = {
             type: 'image',


### PR DESCRIPTION
Addresses #54 and #53 

- Shows error message when renaming a file that does not exist
- Correctly sets custom name when adding a file using `files.addImage()`
- Checks for name collisions when adding image and shows error if name already exists