### PR TITLE
Support for working with local videos

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,18 +9,18 @@ Interactive web-based playground for computer vision and image processing, usefu
 - In-browser JS environment where you write your code
 - [OpenCV](https://docs.opencv.org/3.4.1/d5/d10/tutorial_js_root.html) is preloaded
 - You can import multiple images from your computer
-- Simple API for loading input images and displaying out images
+- Image viewer for displaying output with simple API
+- Importing images and videos
 - Custom widgets supporting multiple control types and pipelines that control function parameters in real time
-- Easy API for working with video streams from a connected camera
+- Easy API for working with video streams from a connected camera or imported video
 
 ## Planned Features
 
 In no particular order, here are some of the features planned:
 
 - Support for Tensorflow.js
-- Support for different file types besides images
+- Support for different file types besides images and videos
 - Load images/videos from the web
-- Support for importing videos
 - Background code execution
 - Console/Stdout emulator
 - Multiple code cells

--- a/src/core/files/types.ts
+++ b/src/core/files/types.ts
@@ -1,10 +1,28 @@
+import { VideoSource } from '@/core/video';
+
+/**
+ * represents a library for managing files,
+ * it provides access to add and read files of
+ * different types
+ * each file has unique name
+ * the implementation is also assumed to track
+ * metadata about each type internally (e.g. type)
+ */
 export interface FileLibrary {
+
     /**
      * adds an image to the file source
      * @param fileUrl object url of the image
      * @param filename optional name for the file, if not provided, one will be auto-assigned
      */
     addImage(fileUrl: string, filename?: string): any;
+
+    /**
+     * adds a video to the file library
+     * @param fileUrl object url of the image
+     * @param filename optional name for the file, if not provided, one will be auto-assigned
+     */
+    addVideo(fileUrl: string, filename?: string): any;
 
     /**
      * reads a specified image from the library as an OpenCv matrix
@@ -14,9 +32,25 @@ export interface FileLibrary {
     readImage(name: string): any;
 
     /**
+     * reads specified video from the library
+     * @param name file name
+     * @returns video
+     */
+    readVideo(name: string): VideoSource;
+
+    /**
+     * reads file based on its type
+     * @param name file name
+     * @returns depends on file type
+     */
+    read(name: string): any;
+
+    /**
      * changes the name of a file in the library
      * @param oldName current name of the file
      * @param newName new name, should be unique in the library
      */
     rename(oldName: string, newName: string): any;
 }
+
+export type FileType = 'image' | 'video';

--- a/src/core/util/index.ts
+++ b/src/core/util/index.ts
@@ -1,0 +1,1 @@
+export { applyMixins } from './mixins';

--- a/src/core/util/mixins.ts
+++ b/src/core/util/mixins.ts
@@ -1,0 +1,12 @@
+/**
+ * applies mixins to a given class
+ * @param derivedCtor target class
+ * @param baseCtors mixins
+ */
+export function applyMixins(derivedCtor: any, baseCtors: any[]) {
+    baseCtors.forEach(baseCtor => {
+        Object.getOwnPropertyNames(baseCtor.prototype).forEach(name => {
+            derivedCtor.prototype[name] = baseCtor.prototype[name];
+        });
+    });
+}

--- a/src/init.ts
+++ b/src/init.ts
@@ -34,6 +34,7 @@ export default function init () {
     samples.addSamples({
         'Quick Intro': codeSamples.QUICK_INTRO,
         'Widgets': codeSamples.WIDGETS,
+        'Video': codeSamples.VIDEO,
         'Camera': codeSamples.CAMERA,
         'Edge Detection': codeSamples.EDGE_DETECTION
     });

--- a/src/samples/index.ts
+++ b/src/samples/index.ts
@@ -1,11 +1,13 @@
 import CAMERA from './camera';
 import EDGE_DETECTION from './edge-detection';
 import QUICK_INTRO from './quick-intro';
+import VIDEO from './video';
 import WIDGETS from './widgets';
 
 export {
     CAMERA,
     EDGE_DETECTION,
     QUICK_INTRO,
+    VIDEO,
     WIDGETS
 };

--- a/src/samples/video.ts
+++ b/src/samples/video.ts
@@ -1,0 +1,8 @@
+export default
+`const { files, imageViewer } = xaval.io;
+
+const video = files.readVideo('file1');
+const stream = video.getStream({ fps: 30 });
+stream.pipe(imageViewer);
+video.play();
+`;

--- a/src/samples/video.ts
+++ b/src/samples/video.ts
@@ -1,8 +1,18 @@
 export default
 `const { files, imageViewer } = xaval.io;
 
+// import video file in the file library
+
+// read imported video
 const video = files.readVideo('file1');
+
+// get video stream and attach it to the image viewer
 const stream = video.getStream({ fps: 30 });
 stream.pipe(imageViewer);
+
+// enable the following line if you want the video to loop
+// video.looping = true
+
+// play the video
 video.play();
 `;

--- a/src/ui/editor/editor.ts
+++ b/src/ui/editor/editor.ts
@@ -1,5 +1,5 @@
 import { Editor } from '@/types';
-import INITIAL_CODE from '@/samples/video';
+import INITIAL_CODE from '@/samples/empty';
 import { EditorProvider } from './types';
 import { createAceEditor } from './ace';
 

--- a/src/ui/editor/editor.ts
+++ b/src/ui/editor/editor.ts
@@ -1,5 +1,5 @@
 import { Editor } from '@/types';
-import INITIAL_CODE from '@/samples/empty';
+import INITIAL_CODE from '@/samples/video';
 import { EditorProvider } from './types';
 import { createAceEditor } from './ace';
 

--- a/src/ui/file-lib/file-lib-view.ts
+++ b/src/ui/file-lib/file-lib-view.ts
@@ -1,5 +1,6 @@
-import { FileLibrary } from '@/core/files';
+import { FileLibrary, FileType } from '@/core/files';
 import { HtmlInputEvent } from '@/types';
+import { FileSource, FileContainer, SourceCtor } from './types';
 import ImageSource from './image-source';
 import VideoSource from './video-source';
 
@@ -8,7 +9,7 @@ export default class FileLibView implements FileLibrary {
     readonly inputEl: HTMLInputElement;
     readonly inputPrompt: HTMLElement;
     readonly thumbnailsEl: HTMLElement;
-    readonly files: { [filename: string]: FileSource } = {};
+    readonly files: { [filename: string]: FileContainer } = {};
     private idCounter = 1;
     
     constructor (el: HTMLElement) {
@@ -36,16 +37,16 @@ export default class FileLibView implements FileLibrary {
         }
     }
 
-    addFile (type: FileType, source: Source, filename?: string) {
+    add (fileUrl:string, ctor: SourceCtor, filename?: string) {
         const id = this.nextId();
         const name = filename || id;
         if (name in this.files) {
             alert(`There's already an imported file called '${name}'.`);
             return;
         }
+        const source = new ctor(fileUrl, name);
         source.el.id = id;
-        const file: FileSource = {
-            type,
+        const file: FileContainer = {
             id,
             name,
             source
@@ -58,13 +59,11 @@ export default class FileLibView implements FileLibrary {
     }
 
     addImage (fileUrl: string, filename: string = '') {
-        const source = new ImageSource(fileUrl, name);
-        this.addFile('image', source, filename);
+        this.add(fileUrl, ImageSource, filename);
     }
 
     addVideo (fileUrl: string, filename: string = '') {
-        const source = new VideoSource(fileUrl, name);
-        this.addFile('image', source, filename);
+        this.add(fileUrl, VideoSource, filename);
     }
 
     readImage (name: string): any {
@@ -94,7 +93,7 @@ export default class FileLibView implements FileLibrary {
         if (!file) {
             alert(`Unknown file ${file}.`);
         }
-        switch (file.type) {
+        switch (file.source.type) {
             case 'image':
                 return this.readImage(name);
             case 'video':
@@ -133,14 +132,3 @@ export default class FileLibView implements FileLibrary {
         this.rename(oldName, newName);
     }
 }
-
-interface FileSource {
-    type: FileType,
-    id: string,
-    name: string,
-    source: Source
-}
-
-type Source = ImageSource | VideoSource;
-
-type FileType = 'image' | 'video';

--- a/src/ui/file-lib/image-source.ts
+++ b/src/ui/file-lib/image-source.ts
@@ -1,6 +1,7 @@
-import { HtmlInputEvent } from '@/types';
+import { FileType } from '@/core/files';
+import { ImageFileSource } from './types';
 
-export default class ImageSource {
+export default class ImageSource implements ImageFileSource {
     private _el: HTMLElement;
     private thumbnail: HTMLImageElement
     private _image: HTMLImageElement;
@@ -25,6 +26,10 @@ export default class ImageSource {
 
     get name (): string {
         return this._name;
+    }
+
+    get type (): FileType {
+        return 'image';
     }
 
     get image () {

--- a/src/ui/file-lib/image-source.ts
+++ b/src/ui/file-lib/image-source.ts
@@ -1,19 +1,17 @@
 import { FileType } from '@/core/files';
+import { applyMixins } from '@/core/util';
 import { ImageFileSource } from './types';
+import { NameUpdatable } from './mixins';
 
-export default class ImageSource implements ImageFileSource {
+
+export default class Source implements ImageFileSource {
     private _el: HTMLElement;
-    private thumbnail: HTMLImageElement
+    private _thumbnail: HTMLImageElement
     private _image: HTMLImageElement;
-    private nameEl: HTMLInputElement;
+    private _nameEl: HTMLInputElement;
     private _name: string;
-    constructor (src: string, name: string) {
-        this._el = this.createHtml();
-        this._image = new Image();
-        this.thumbnail.src = src;
-        this._image.src = src;
-        this.name = name;
-    }
+
+    onNameChanged: (handler: (newName: string) => any) => any;
 
     get el (): HTMLElement {
         return this._el;
@@ -21,7 +19,7 @@ export default class ImageSource implements ImageFileSource {
 
     set name (val: string) {
         this._name = val;
-        this.nameEl.value = val;
+        this._nameEl.value = val;
     }
 
     get name (): string {
@@ -39,22 +37,15 @@ export default class ImageSource implements ImageFileSource {
     private createHtml () {
         this._el = document.createElement('div');
         this._el.classList.add('file-source', 'image-source');
-        this.thumbnail = document.createElement('img');
-        this.thumbnail.classList.add('thumbnail');
-        this.nameEl = document.createElement('input');
-        this.nameEl.type = 'text';
-        this.nameEl.classList.add('filename');
-        this._el.appendChild(this.thumbnail);
-        this._el.appendChild(this.nameEl);
+        this._thumbnail = document.createElement('img');
+        this._thumbnail.classList.add('thumbnail');
+        this._nameEl = document.createElement('input');
+        this._nameEl.type = 'text';
+        this._nameEl.classList.add('filename');
+        this._el.appendChild(this._thumbnail);
+        this._el.appendChild(this._nameEl);
         return this._el;
     }
-
-    onNameChanged (handler: (newName: string) => any) {
-        this.nameEl.addEventListener('change', () => {
-            const newName = this.nameEl.value;
-            if (newName !== this.name) {
-                handler(newName);
-            }
-        });
-    }
 }
+
+applyMixins(Source, [NameUpdatable]);

--- a/src/ui/file-lib/mixins.ts
+++ b/src/ui/file-lib/mixins.ts
@@ -1,0 +1,12 @@
+export class NameUpdatable {
+    nameEl: HTMLInputElement;
+    name: string;
+    onNameChanged (handler: (newName: string) => any) {
+        this.nameEl.addEventListener('change', () => {
+            const newName = this.nameEl.value;
+            if (newName !== this.name) {
+                handler(newName);
+            }
+        });
+    }
+}

--- a/src/ui/file-lib/types.ts
+++ b/src/ui/file-lib/types.ts
@@ -1,0 +1,3 @@
+export interface FileListItem {
+    name: string;
+}

--- a/src/ui/file-lib/types.ts
+++ b/src/ui/file-lib/types.ts
@@ -1,3 +1,27 @@
-export interface FileListItem {
+import { FileType } from '@/core/files';
+import { Video } from '@/ui/video';
+
+export interface FileSource {
+    el: HTMLElement;
+    type: FileType;
     name: string;
+    onNameChanged (handler: (newName: string) => any): any;
+}
+
+export interface ImageFileSource extends FileSource {
+    image: HTMLImageElement;
+}
+
+export interface VideoFileSource extends FileSource {
+    video: Video;
+}
+
+export interface SourceCtor {
+    new (src: string, name: string): FileSource;
+}
+
+export interface FileContainer {
+    id: string,
+    name: string,
+    source: FileSource
 }

--- a/src/ui/file-lib/video-source.ts
+++ b/src/ui/file-lib/video-source.ts
@@ -1,6 +1,8 @@
 import { Video } from '@/ui/video';
+import { FileType } from '@/core/files';
+import { VideoFileSource } from './types';
 
-export default class  {
+export default class implements VideoFileSource {
     private _el: HTMLElement;
     private _thumbnail: HTMLElement;
     private _nameEl: HTMLInputElement;
@@ -10,7 +12,7 @@ export default class  {
     constructor (src: string, name: string) {
         this._el = this.createHtml();
         this._video = new Video(src);
-        this._name = name;
+        this.name = name;
     }
 
     get el (): HTMLElement {
@@ -24,6 +26,10 @@ export default class  {
 
     get name (): string {
         return this._name;
+    }
+
+    get type (): FileType {
+        return 'video';
     }
 
     get video (): Video {

--- a/src/ui/file-lib/video-source.ts
+++ b/src/ui/file-lib/video-source.ts
@@ -26,6 +26,10 @@ export default class  {
         return this._name;
     }
 
+    get video (): Video {
+        return this._video;
+    }
+
     private createHtml () {
         this._el = document.createElement('div');
         this._el.classList.add('file-source', 'video-source');

--- a/src/ui/file-lib/video-source.ts
+++ b/src/ui/file-lib/video-source.ts
@@ -6,7 +6,7 @@ import { NameUpdatable } from './mixins';
 
 export default class Source implements VideoFileSource, NameUpdatable {
     private _el: HTMLElement;
-    private _thumbnail: HTMLElement;
+    private _thumbnail: HTMLImageElement;
     private _nameEl: HTMLInputElement;
     private _video: Video;
     private _name: string;
@@ -17,6 +17,9 @@ export default class Source implements VideoFileSource, NameUpdatable {
         this._el = this.createHtml();
         this._video = new Video(src);
         this.name = name;
+        this._video.onPosterReady(() => {
+            this._thumbnail.src = this._video.poster;
+        });
     }
 
     get el (): HTMLElement {

--- a/src/ui/file-lib/video-source.ts
+++ b/src/ui/file-lib/video-source.ts
@@ -1,0 +1,50 @@
+import { Video } from '@/ui/video';
+
+export default class  {
+    private _el: HTMLElement;
+    private _thumbnail: HTMLElement;
+    private _nameEl: HTMLInputElement;
+    private _video: Video;
+    private _name: string;
+
+    constructor (src: string, name: string) {
+        this._el = this.createHtml();
+        this._video = new Video(src);
+        this._name = name;
+    }
+
+    get el (): HTMLElement {
+        return this._el;
+    }
+
+    set name (val: string) {
+        this._name = val;
+        this._nameEl.value = val;
+    }
+
+    get name (): string {
+        return this._name;
+    }
+
+    private createHtml () {
+        this._el = document.createElement('div');
+        this._el.classList.add('file-source', 'video-source');
+        this._thumbnail = document.createElement('img');
+        this._thumbnail.classList.add('thumbnail');
+        this._nameEl = document.createElement('input');
+        this._nameEl.type = 'text';
+        this._nameEl.classList.add('filename');
+        this._el.appendChild(this._thumbnail);
+        this._el.appendChild(this._nameEl);
+        return this._el;
+    }
+
+    onNameChanged (handler: (newName: string) => any) {
+        this._nameEl.addEventListener('change', () => {
+            const newName = this._nameEl.value;
+            if (newName !== this._name) {
+                handler(newName);
+            }
+        });
+    }
+}

--- a/src/ui/file-lib/video-source.ts
+++ b/src/ui/file-lib/video-source.ts
@@ -1,13 +1,17 @@
 import { Video } from '@/ui/video';
+import { applyMixins } from '@/core/util';
 import { FileType } from '@/core/files';
 import { VideoFileSource } from './types';
+import { NameUpdatable } from './mixins';
 
-export default class implements VideoFileSource {
+export default class Source implements VideoFileSource, NameUpdatable {
     private _el: HTMLElement;
     private _thumbnail: HTMLElement;
     private _nameEl: HTMLInputElement;
     private _video: Video;
     private _name: string;
+
+    onNameChanged: (handler: (newName: string) => any) => any;
 
     constructor (src: string, name: string) {
         this._el = this.createHtml();
@@ -36,6 +40,10 @@ export default class implements VideoFileSource {
         return this._video;
     }
 
+    get nameEl () {
+        return this._nameEl;
+    }
+
     private createHtml () {
         this._el = document.createElement('div');
         this._el.classList.add('file-source', 'video-source');
@@ -48,13 +56,6 @@ export default class implements VideoFileSource {
         this._el.appendChild(this._nameEl);
         return this._el;
     }
-
-    onNameChanged (handler: (newName: string) => any) {
-        this._nameEl.addEventListener('change', () => {
-            const newName = this._nameEl.value;
-            if (newName !== this._name) {
-                handler(newName);
-            }
-        });
-    }
 }
+
+applyMixins(Source, [NameUpdatable]);

--- a/src/ui/index.html
+++ b/src/ui/index.html
@@ -34,7 +34,7 @@
                 </button>
                 <div class="thumbnails">
                 </div>
-                <input id="filesInput" type="file" name="file" accept="image/*" multiple>
+                <input id="filesInput" type="file" name="file" accept="" multiple>
             </div>
         </div>
     </div>

--- a/src/ui/video/index.ts
+++ b/src/ui/video/index.ts
@@ -1,0 +1,1 @@
+export { Video } from './video';

--- a/src/ui/video/video.ts
+++ b/src/ui/video/video.ts
@@ -8,22 +8,36 @@ export class Video implements VideoSource {
     private _playing: boolean;
     private _onPlayHandler: any;
     private _onPauseHandler: any;
+    private _onEndHandler: any;
+    private _poster: string;
+    private _posterReadyHandler: any;
 
     constructor (src: string) {
         this._video = document.createElement('video');
         this._video.muted = true;
+        this._video.preload = 'auto';
         this._video.src = src;
         this._video.addEventListener('canplay', () => {
             this.onVideoReady();
         });
         this._onPlayHandler = this.onVideoPlaying.bind(this);
         this._onPauseHandler = this.onVideoPaused.bind(this);
+        this._onEndHandler = this.onVideoEnded.bind(this);
     }
 
     private onVideoReady () {
         this._video.width = this._video.videoWidth;
         this._video.height = this._video.videoHeight;
         this._capture = new cv.VideoCapture(this._video);
+        if (!this._poster) {
+            this._poster = this._video.poster;
+            if (this._posterReadyHandler) {
+                this._posterReadyHandler();
+            }
+        }
+        this._video.addEventListener('play', this._onPlayHandler);
+        this._video.addEventListener('pause', this._onPauseHandler);
+        this._video.addEventListener('ended', this._onEndHandler);
     }
 
     private onVideoPlaying () {
@@ -40,6 +54,10 @@ export class Video implements VideoSource {
         }
     }
 
+    private onVideoEnded () {
+        this.onVideoPaused();
+    }
+
     get width () {
         return this._video.width;
     }
@@ -48,8 +66,36 @@ export class Video implements VideoSource {
         return this._video.height;
     }
 
+    get poster () {
+        return this._poster;
+    }
+
     get playing () {
         return this._playing;
+    }
+
+    get looping (): boolean {
+        return this._video.loop;
+    }
+
+    set looping (val: boolean) {
+        this._video.loop = val;
+    }
+
+    get ended (): boolean {
+        return this._video.ended;
+    }
+
+    get duration (): number {
+        return this._video.duration;
+    }
+
+    get currentTime (): number {
+        return this._video.currentTime;
+    }
+
+    set currentTime (time: number) {
+        this._video.currentTime = time;
     }
 
     /**
@@ -87,8 +133,6 @@ export class Video implements VideoSource {
 
     play () {
         this._video.play();
-        this._video.addEventListener('play', this._onPlayHandler);
-        this._video.addEventListener('pause', this._onPauseHandler);
     }
 
     pause () {
@@ -108,5 +152,9 @@ export class Video implements VideoSource {
             this._stream = null;
         }
         this.deleteCaptureDest();
+    }
+
+    onPosterReady (handler: any) {
+        this._posterReadyHandler = handler;
     }
 }

--- a/src/ui/video/video.ts
+++ b/src/ui/video/video.ts
@@ -1,0 +1,112 @@
+import { VideoSource, VideoStream, VideoStreamParams } from '@/core/video';
+
+export class Video implements VideoSource {
+    private _video: HTMLVideoElement;
+    private _capture: any;
+    private _captureDest: any;
+    private _stream: VideoStream;
+    private _playing: boolean;
+    private _onPlayHandler: any;
+    private _onPauseHandler: any;
+
+    constructor (src: string) {
+        this._video = document.createElement('video');
+        this._video.muted = true;
+        this._video.src = src;
+        this._video.addEventListener('canplay', () => {
+            this.onVideoReady();
+        });
+        this._onPlayHandler = this.onVideoPlaying.bind(this);
+        this._onPauseHandler = this.onVideoPaused.bind(this);
+    }
+
+    private onVideoReady () {
+        this._video.width = this._video.videoWidth;
+        this._video.height = this._video.videoHeight;
+        this._capture = new cv.VideoCapture(this._video);
+    }
+
+    private onVideoPlaying () {
+        this._playing = true;
+        if (this._stream && this._stream.params.autoStart && !this._stream.streaming) {
+            this._stream.start();
+        }
+    }
+
+    private onVideoPaused () {
+        this._playing = false;
+        if (this._stream && this._stream.streaming) {
+            this._stream.stop();
+        }
+    }
+
+    get width () {
+        return this._video.width;
+    }
+
+    get height () {
+        return this._video.height;
+    }
+
+    get playing () {
+        return this._playing;
+    }
+
+    /**
+     * OpenCV matrix used to store captured video frame
+     */
+    private get captureDest () {
+        if (!this._captureDest || this._captureDest.isDeleted()) {
+            this._captureDest = new cv.Mat(this.height, this.width, cv.CV_8UC4);
+        }
+        return this._captureDest;
+    }
+
+    private deleteCaptureDest () {
+        if (this._captureDest && !this._captureDest.isDeleted()) {
+            this._captureDest.delete();
+            this._captureDest = null;
+        }
+    }
+    
+    read (dest?: any) {
+        dest = dest || this.captureDest;
+        this._capture.read(dest);
+        return dest;
+    }
+
+    getStream (params: VideoStreamParams) {
+        if (!this._stream) {
+            params = { autoStart: true, ...params };
+            this._stream = new VideoStream(this, params);
+            // check if playing first
+            this._stream.start();
+        }
+        return this._stream;
+    }
+
+    play () {
+        this._video.play();
+        this._video.addEventListener('play', this._onPlayHandler);
+        this._video.addEventListener('pause', this._onPauseHandler);
+    }
+
+    pause () {
+        this._video.pause();
+    }
+
+    stop () {
+        if (this._video) {
+            this._video.pause();
+            this._video.srcObject = null;
+            this._video.removeEventListener('play', this._onPlayHandler);
+            this._video.removeEventListener('pause', this._onPauseHandler);
+        }
+
+        if (this._stream) {
+            this._stream.stop();
+            this._stream = null;
+        }
+        this.deleteCaptureDest();
+    }
+}


### PR DESCRIPTION
Addresses issue #9 

This PR allows you to import local video files and work with them similar to cameras, but with a more extensive API.

Changes:

- `files.addVideo(url, name)` added to file library
- `files.readVideo(name)` added to file library

`files.readVideo()` returns a `Video` object, which likes `Camera`, implements `VideoSource` (so you can do `video.getStream(params)` and `video.read()`.

But `Video` objects also have the following properties and methods:

**Properties**

- `playing`: whether it's playing
- `paused`: whether the video's paused
- `ended`: whether the video's ended
- `duration`: duration
- `looping`: sets or gets whether the video will loop after reaching the end
- `currentTime`: current time
- `poster`: the url of the poster image, at the moment it's always empty

**Methods**

- `play()`: plays the video (and starts the stream if it's on `autoStart`)
- `pause()`: pauses the video, the video can still be resumed by calling `video.play()`
- `stop()`: stops the video and releases attached resources, including the stream


There needs to be more work to be done for this API to be "complete", like using a frame of the video as the poster, providing a way to be notified of the underlying video events, like seeked, ended, etc.
