### PR TITLE
Restore image source constructor

### DIFF
--- a/src/ui/file-lib/image-source.ts
+++ b/src/ui/file-lib/image-source.ts
@@ -13,6 +13,14 @@ export default class Source implements ImageFileSource {
 
     onNameChanged: (handler: (newName: string) => any) => any;
 
+    constructor (src: string, name: string) {
+        this._el = this.createHtml();
+        this._image = new Image();
+        this._thumbnail.src = src;
+        this._image.src = src;
+        this._name = name;
+    }
+
     get el (): HTMLElement {
         return this._el;
     }


### PR DESCRIPTION
The `constructor` was missing in `ImageFileSource`, leading to errors. Must have removed it by mistake when refactoring.