### PR TITLE
Other file types

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,7 @@ Interactive web-based playground for computer vision and image processing, usefu
 - You can import multiple images from your computer
 - Image viewer for displaying output with simple API
 - Importing images and videos
+- Importing blobs
 - Custom widgets supporting multiple control types and pipelines that control function parameters in real time
 - Easy API for working with video streams from a connected camera or imported video
 
@@ -19,7 +20,6 @@ Interactive web-based playground for computer vision and image processing, usefu
 In no particular order, here are some of the features planned:
 
 - Support for Tensorflow.js
-- Support for different file types besides images and videos
 - Load images/videos from the web
 - Background code execution
 - Console/Stdout emulator

--- a/src/core/files/types.ts
+++ b/src/core/files/types.ts
@@ -75,7 +75,7 @@ export interface BinaryFileReader {
     /**
      * the object url of the file.
      */
-    objectURL: string;
+    url: string;
 
     /**
      * reads the contents of the file as text

--- a/src/core/files/types.ts
+++ b/src/core/files/types.ts
@@ -66,7 +66,7 @@ export interface FileLibrary {
     rename(oldName: string, newName: string): any;
 }
 
-export type FileType = 'image' | 'video';
+export type FileType = 'image' | 'video' | 'binary';
 
 /**
  * represents a wrapper around a blob

--- a/src/core/files/types.ts
+++ b/src/core/files/types.ts
@@ -25,6 +25,13 @@ export interface FileLibrary {
     addVideo(fileUrl: string, filename?: string): any;
 
     /**
+     * adds a file of an arbitrary type
+     * @param file blob containing the file
+     * @param filename optional name assigned to the file in the library
+     */
+    addBinary(file: Blob, filename?: string): any;
+
+    /**
      * reads a specified image from the library as an OpenCv matrix
      * @param name file name
      * @returns {cv.Mat} OpenCV matrix containing the image
@@ -37,6 +44,12 @@ export interface FileLibrary {
      * @returns video
      */
     readVideo(name: string): VideoSource;
+
+    /**
+     * returns a reader to access the specified file as a blob
+     * @param name 
+     */
+    getReader(name: string): BinaryFileReader;
 
     /**
      * reads file based on its type

--- a/src/core/files/types.ts
+++ b/src/core/files/types.ts
@@ -54,3 +54,23 @@ export interface FileLibrary {
 }
 
 export type FileType = 'image' | 'video';
+
+/**
+ * represents a wrapper around a blob
+ */
+export interface BinaryFileReader {
+    /**
+     * reads the contents of the file as text
+     */
+    readText(): Promise<any>;
+
+    /**
+     * returns the contents of the file as an ArrayBuffer
+     */
+    readBuffer(): Promise<any>;
+
+    /**
+     * returns the contents of the file as data url
+     */
+    readDataURL(): Promise<any>;
+}

--- a/src/core/files/types.ts
+++ b/src/core/files/types.ts
@@ -73,6 +73,11 @@ export type FileType = 'image' | 'video';
  */
 export interface BinaryFileReader {
     /**
+     * the object url of the file.
+     */
+    objectURL: string;
+
+    /**
      * reads the contents of the file as text
      */
     readText(): Promise<any>;

--- a/src/ui/file-lib/binary-file-reader.ts
+++ b/src/ui/file-lib/binary-file-reader.ts
@@ -11,7 +11,7 @@ export default class implements BinaryFileReader {
         this._url = URL.createObjectURL(file);
     }
 
-    get objectURL () {
+    get url () {
         return this._url;
     }
 

--- a/src/ui/file-lib/binary-file-reader.ts
+++ b/src/ui/file-lib/binary-file-reader.ts
@@ -3,10 +3,16 @@ import { BinaryFileReader } from '@/core/files';
 export default class implements BinaryFileReader {
     _reader: FileReader;
     _file: Blob;
+    _url: string;
 
     constructor (file: Blob) {
         this._file = file;
         this._reader = new FileReader();
+        this._url = URL.createObjectURL(file);
+    }
+
+    get objectURL () {
+        return this._url;
     }
 
     _read (type: Type) {

--- a/src/ui/file-lib/binary-file-reader.ts
+++ b/src/ui/file-lib/binary-file-reader.ts
@@ -1,0 +1,46 @@
+import { BinaryFileReader } from '@/core/files';
+
+export default class implements BinaryFileReader {
+    _reader: FileReader;
+    _file: Blob;
+
+    constructor (file: Blob) {
+        this._file = file;
+        this._reader = new FileReader();
+    }
+
+    _read (type: Type) {
+        return new Promise ((resolve, reject) => {
+            this._reader.onloadend = () => {
+                resolve(this._reader.result);
+            };
+            this._reader.onerror = (e: any) => {
+                const error = e.error || new Error('Error reading file');
+                reject(error);
+            }
+            if (type === 'text') {
+                this._reader.readAsText(this._file);
+            }
+            else if (type === 'url') {
+                this._reader.readAsDataURL(this._file);
+            }
+            else {
+                this._reader.readAsArrayBuffer(this._file);
+            }
+        });
+    }
+
+    readText () {
+        return this._read('text');
+    }
+
+    readBuffer () {
+        return this._read('buffer');
+    }
+
+    readDataURL () {
+        return this._read('url');
+    }
+}
+
+type Type = 'text' | 'buffer' | 'url';

--- a/src/ui/file-lib/binary-source.ts
+++ b/src/ui/file-lib/binary-source.ts
@@ -34,7 +34,7 @@ export default class Source implements BinaryFileSource, NameUpdatable {
     }
 
     get type (): FileType {
-        return 'video';
+        return 'binary';
     }
 
     get nameEl () {

--- a/src/ui/file-lib/binary-source.ts
+++ b/src/ui/file-lib/binary-source.ts
@@ -1,0 +1,62 @@
+import { applyMixins } from '@/core/util';
+import { FileType, BinaryFileReader } from '@/core/files';
+import { BinaryFileSource } from './types';
+import { NameUpdatable } from './mixins';
+import Reader from './binary-file-reader';
+
+export default class Source implements BinaryFileSource, NameUpdatable {
+    private _el: HTMLElement;
+    private _thumbnail: HTMLImageElement;
+    private _nameEl: HTMLInputElement;
+    private _reader: BinaryFileReader;
+    private _name: string;
+    private _contents: any;
+
+    onNameChanged: (handler: (newName: string) => any) => any;
+
+    constructor (file: Blob, name: string) {
+        this._el = this.createHtml();
+        this._reader = new Reader(file);
+        this.name = name;
+    }
+
+    get el (): HTMLElement {
+        return this._el;
+    }
+
+    set name (val: string) {
+        this._name = val;
+        this._nameEl.value = val;
+    }
+
+    get name (): string {
+        return this._name;
+    }
+
+    get type (): FileType {
+        return 'video';
+    }
+
+    get nameEl () {
+        return this._nameEl;
+    }
+
+    get reader () {
+        return this._reader;
+    }
+
+    private createHtml () {
+        this._el = document.createElement('div');
+        this._el.classList.add('file-source', 'video-source');
+        this._thumbnail = document.createElement('img');
+        this._thumbnail.classList.add('thumbnail');
+        this._nameEl = document.createElement('input');
+        this._nameEl.type = 'text';
+        this._nameEl.classList.add('filename');
+        this._el.appendChild(this._thumbnail);
+        this._el.appendChild(this._nameEl);
+        return this._el;
+    }
+}
+
+applyMixins(Source, [NameUpdatable]);

--- a/src/ui/file-lib/file-lib-view.ts
+++ b/src/ui/file-lib/file-lib-view.ts
@@ -3,6 +3,7 @@ import { HtmlInputEvent } from '@/types';
 import { FileSource, FileContainer, SourceCtor } from './types';
 import ImageSource from './image-source';
 import VideoSource from './video-source';
+import BinarySource from './binary-source';
 
 export default class FileLibView implements FileLibrary {
     readonly el: HTMLElement;
@@ -32,12 +33,15 @@ export default class FileLibView implements FileLibrary {
                 this.addImage(url);
             }
             else if (/video/.test(item.type)) {
-                this.addVideo(url)
+                this.addVideo(url);
+            }
+            else {
+                this.addBinary(item);
             }
         }
     }
 
-    add (fileUrl:string, ctor: SourceCtor, filename?: string) {
+    add (fileUrl: string | Blob, ctor: SourceCtor, filename?: string) {
         const id = this.nextId();
         const name = filename || id;
         if (name in this.files) {
@@ -66,10 +70,14 @@ export default class FileLibView implements FileLibrary {
         this.add(fileUrl, VideoSource, filename);
     }
 
+    addBinary (file: Blob, filename: string = '') {
+        this.add(file, BinarySource, filename);
+    }
+
     readImage (name: string): any {
         const file = this.files[name];
-        if (file.source instanceof ImageSource) {
-            return file && cv.imread(file.source.image);
+        if (file && file.source instanceof ImageSource) {
+            return cv.imread(file.source.image);
         } else {
             // TODO: throw error instead
             return null;
@@ -78,13 +86,23 @@ export default class FileLibView implements FileLibrary {
 
     readVideo (name: string): any {
         const file = this.files[name];
-        if (file.source instanceof VideoSource) {
-            return file && file.source.video;
+        if (file && file.source instanceof VideoSource) {
+            return file.source.video;
         } else {
             // TODO: throw error instead
             return null;
         }
 
+    }
+
+    getReader (name: string) {
+        const file = this.files[name];
+        if (file && file.source instanceof BinarySource) {
+            return file.source.reader;
+        } else {
+            // TODO: throw error instead
+            return null;
+        }
     }
 
     read (name: string): any {

--- a/src/ui/file-lib/file-lib-view.ts
+++ b/src/ui/file-lib/file-lib-view.ts
@@ -116,6 +116,8 @@ export default class FileLibView implements FileLibrary {
                 return this.readImage(name);
             case 'video':
                 return this.readVideo(name);
+            case 'binary':
+                return this.getReader(name);
             default:
                 return null;
         }

--- a/src/ui/file-lib/image-source.ts
+++ b/src/ui/file-lib/image-source.ts
@@ -4,7 +4,7 @@ import { ImageFileSource } from './types';
 import { NameUpdatable } from './mixins';
 
 
-export default class Source implements ImageFileSource {
+export default class Source implements ImageFileSource, NameUpdatable {
     private _el: HTMLElement;
     private _thumbnail: HTMLImageElement
     private _image: HTMLImageElement;
@@ -40,6 +40,10 @@ export default class Source implements ImageFileSource {
 
     get image () {
         return this._image;
+    }
+
+    get nameEl () {
+        return this._nameEl;
     }
 
     private createHtml () {

--- a/src/ui/file-lib/types.ts
+++ b/src/ui/file-lib/types.ts
@@ -1,4 +1,4 @@
-import { FileType } from '@/core/files';
+import { FileType, BinaryFileReader } from '@/core/files';
 import { Video } from '@/ui/video';
 
 export interface FileSource {
@@ -16,8 +16,12 @@ export interface VideoFileSource extends FileSource {
     video: Video;
 }
 
+export interface BinaryFileSource extends FileSource {
+    reader: BinaryFileReader;
+}
+
 export interface SourceCtor {
-    new (src: string, name: string): FileSource;
+    new (file: Blob | string, name: string): FileSource;
 }
 
 export interface FileContainer {


### PR DESCRIPTION
Addresses #61 

Now you can upload arbitrary file blobs into Xaval. To access them, use `files.getReader(name)`, this returns an instance of `BinaryFileReader` which provides methods for asynchronously retrieving the file contents in different formats (text, data url and array buffer) as well as a `.url` property containing the object url:

```javascript
const blob = files.getReader('file1');
blob.readText().then(text => console.log(text));
blob.readBuffer().then(buffer => console.log(buffer));
blob.readDataURL().then(dataUrl => console.log(dataUrl);

// get object url
console.log(blob.url);

```

`getReader()` is probably not a good name. Maybe I should rename it to `readBinary` or `readBlob` or something else.

Furthermore, these files have blank thumbnails. I will create an issue to address that.